### PR TITLE
Fix retry task ignoring admin UI disable on restart

### DIFF
--- a/api/src/main/java/org/openmrs/module/outgoingmessageexceptions/OutgoingMessageExceptionsActivator.java
+++ b/api/src/main/java/org/openmrs/module/outgoingmessageexceptions/OutgoingMessageExceptionsActivator.java
@@ -29,8 +29,7 @@ public class OutgoingMessageExceptionsActivator extends BaseModuleActivator {
 	@Override
 	public void started() {
 		LOGGER.info("Started Outgoing Message Exceptions");
-		// getRetrySchedulerService().createTaskIfNotExists();
-		getRetrySchedulerService().stopTaskIfExists();
+		getRetrySchedulerService().createTaskIfNotExists();
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/module/outgoingmessageexceptions/api/retry/impl/RetrySchedulerServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/outgoingmessageexceptions/api/retry/impl/RetrySchedulerServiceImpl.java
@@ -21,27 +21,29 @@ public class RetrySchedulerServiceImpl implements RetrySchedulerService {
 	}
 	
 	private void createTaskIfNotExists(String name, String description, Class retryClass, Long interval) {
-		TaskDefinition result = Context.getSchedulerService().getTaskByName(name);
-		
-		if (result == null) {
-			result = new TaskDefinition();
-			
-			result.setName(name);
-			result.setDescription(description);
-			result.setTaskClass(retryClass.getName());
-			result.setRepeatInterval(interval);
-			result.setStartTime(new Timestamp(System.currentTimeMillis()));
-			result.setStartOnStartup(true);
-			result.setCreator(Context.getAuthenticatedUser());
-			
-			try {
-				Context.getSchedulerService().saveTaskDefinition(result);
-				Context.getSchedulerService().scheduleTask(
-						Context.getSchedulerService().getTaskByName(name));
-				LOGGER.info("Created new scheduler task '{}'", name);
-			} catch (Exception e) {
-				LOGGER.error("Error during creating scheduler task '{}'", name, e);
-			}
+		SchedulerService ss = Context.getSchedulerService();
+		TaskDefinition result = ss.getTaskByName(name);
+
+		if (result != null) {
+			result.setStarted(false);
+			ss.deleteTask(result.getId());
+		}
+
+		result = new TaskDefinition();
+		result.setName(name);
+		result.setDescription(description);
+		result.setTaskClass(retryClass.getName());
+		result.setRepeatInterval(interval);
+		result.setStartTime(new Timestamp(System.currentTimeMillis()));
+		result.setStartOnStartup(false);
+		result.setCreator(Context.getAuthenticatedUser());
+
+		try {
+			ss.saveTaskDefinition(result);
+			ss.scheduleTask(ss.getTaskByName(name));
+			LOGGER.info("Created new scheduler task '{}'", name);
+		} catch (Exception e) {
+			LOGGER.error("Error during creating scheduler task '{}'", name, e);
 		}
 	}
 


### PR DESCRIPTION
## Problem

The retry task was created with `startOnStartup=true` which causes OpenMRS to auto-start it on every boot regardless of whether it was disabled via the admin Manage Scheduled Tasks UI.

The previous workaround (commenting out `createTaskIfNotExists` and calling `stopTaskIfExists` did not work because OpenMRS reads `startOnStartup` from the database and starts the task before any module activator runs.

The retry task processes failed PIX/PDQ/XDS messages. On sites where MPI is not configured, these retries produce hundreds of errors per cycle:

```
ERROR - PixRetryInvoker.retry(72) | Unsuccessful retry
    at org.openmrs.module.outgoingmessageexceptions.api.retry.impl.RetryServiceImpl.retryAll(RetryServiceImpl.java:28)
    at org.openmrs.module.outgoingmessageexceptions.api.retry.impl.RetryTask.execute(RetryTask.java:22)

ERROR - DocumentBuilderImpl.generate(239) | org.marc.everest.exceptions.DuplicateItemException
    at org.openmrs.module.outgoingmessageexceptions.api.retry.impl.XdsBRetryInvoker.retry(XdsBRetryInvoker.java:42)
    at org.openmrs.module.outgoingmessageexceptions.api.retry.impl.RetryServiceImpl.retryAll(RetryServiceImpl.java:33)
    at org.openmrs.module.outgoingmessageexceptions.api.retry.impl.RetryTask.execute(RetryTask.java:22)
```

## Fix

- Restore `createTaskIfNotExists()` in the activator, remove the `stopTaskIfExists()` workaround
- On each startup, delete any existing task definition and recreate it with `startOnStartup=false`. This clears any stale flag from the database. The task runs for the current session via `scheduleTask()` but won't auto-start on next boot.

## Changes

- `OutgoingMessageExceptionsActivator.java` — restore `createTaskIfNotExists()`, remove `stopTaskIfExists()` workaround
- `RetrySchedulerServiceImpl.java` — delete existing task before creating fresh with `startOnStartup=false`