### PR TITLE
Add CI and release workflows with GitHub Packages publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: Build, Test & Publish
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  release:
+    types: [ created ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      RELEASE_USERNAME: ${{ github.actor }}
+      RELEASE_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v5.2.0
+        with:
+          java-version: '8'
+          distribution: zulu
+          cache: maven
+          server-id: github-packages
+          server-username: RELEASE_USERNAME
+          server-password: RELEASE_TOKEN
+
+      - name: Build and test
+        run: mvn -B -P github-packages clean package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,4 @@ jobs:
           server-password: RELEASE_TOKEN
 
       - name: Build and test
-        run: mvn -B -P github-packages clean package
+        run: mvn -B -P github-packages -Duser.timezone=CET -DargLine="-Duser.timezone=CET" clean package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version'
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+
+    env:
+      RELEASE_USERNAME: ${{ github.actor }}
+      RELEASE_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v5.2.0
+        with:
+          java-version: '8'
+          distribution: zulu
+          cache: maven
+          server-id: github-packages
+          server-username: RELEASE_USERNAME
+          server-password: RELEASE_TOKEN
+
+      - name: Set release version
+        run: |
+          mvn versions:set -DnewVersion=${{ github.event.inputs.version }} -DgenerateBackupPoms=false
+          echo "Set version to ${{ github.event.inputs.version }}"
+
+      - name: Build
+        run: mvn -B -P github-packages -DskipTests -Dfindbugs.skip=true -Dpmd.skip=true -Dcpd.skip=true clean package
+
+      - name: Publish to GitHub Packages
+        run: mvn -B -P github-packages -DskipTests -Dfindbugs.skip=true -Dpmd.skip=true -Dcpd.skip=true deploy
+
+      - name: Create release
+        uses: softprops/action-gh-release@v3.0.0
+        with:
+          tag_name: v${{ github.event.inputs.version }}
+          name: v${{ github.event.inputs.version }}
+          generate_release_notes: true
+          files: omod/target/*.omod
+
+      - name: Bump to next SNAPSHOT
+        run: |
+          IFS='.' read -r major minor patch <<< "${{ github.event.inputs.version }}"
+          next_patch=$((patch + 1))
+          next_version="${major}.${minor}.${next_patch}-SNAPSHOT"
+          mvn versions:set -DnewVersion=${next_version} -DgenerateBackupPoms=false
+          echo "Bumped to ${next_version}"
+
+      - name: Commit version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pom.xml api/pom.xml omod/pom.xml
+          git commit -m "Bump version to next SNAPSHOT after v${{ github.event.inputs.version }} release"
+          git push

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: java
-jdk:
-  - oraclejdk8

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -155,4 +155,40 @@
 		</plugins>
 	</build>
 
+	<profiles>
+		<profile>
+			<id>github-packages</id>
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-deploy-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>default-deploy</id>
+								<phase>none</phase>
+							</execution>
+							<execution>
+								<id>deploy-omod</id>
+								<phase>deploy</phase>
+								<goals>
+									<goal>deploy-file</goal>
+								</goals>
+								<configuration>
+									<url>https://maven.pkg.github.com/isanteplus/isanteplus-packages</url>
+									<file>target/${project.parent.artifactId}-${project.version}.omod</file>
+									<repositoryId>github-packages</repositoryId>
+									<packaging>omod</packaging>
+									<generatePom>false</generatePom>
+									<artifactId>${project.parent.artifactId}-omod</artifactId>
+									<version>${project.version}</version>
+									<groupId>${project.groupId}</groupId>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		<emrapiVersion>1.21.0</emrapiVersion>
 		<coreappsVersion>1.13.0</coreappsVersion>
 		<registrationcoreVersion>1.9.0</registrationcoreVersion>
-		<xdssenderVersion>2.5.6</xdssenderVersion>
+		<xdssenderVersion>2.6.0</xdssenderVersion>
 		<gsonVersion>2.8.1</gsonVersion>
 		<fasterXmlJacksonVersion>2.9.10.5</fasterXmlJacksonVersion>
 		<legacyuiVersion>1.0</legacyuiVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		<emrapiVersion>1.21.0</emrapiVersion>
 		<coreappsVersion>1.13.0</coreappsVersion>
 		<registrationcoreVersion>1.9.0</registrationcoreVersion>
-		<xdssenderVersion>2.5.7-SNAPSHOT</xdssenderVersion>
+		<xdssenderVersion>2.5.6</xdssenderVersion>
 		<gsonVersion>2.8.1</gsonVersion>
 		<fasterXmlJacksonVersion>2.9.10.5</fasterXmlJacksonVersion>
 		<legacyuiVersion>1.0</legacyuiVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,33 @@
 		</pluginRepository>
 	</pluginRepositories>
 
+	<profiles>
+		<profile>
+			<id>github-packages</id>
+			<distributionManagement>
+				<repository>
+					<id>github-packages</id>
+					<name>Github iSantePlus Packages</name>
+					<url>https://maven.pkg.github.com/isanteplus/isanteplus-packages</url>
+					<uniqueVersion>false</uniqueVersion>
+				</repository>
+				<snapshotRepository>
+					<id>github-packages</id>
+					<name>Github iSantePlus Packages</name>
+					<url>https://maven.pkg.github.com/isanteplus/isanteplus-packages</url>
+					<uniqueVersion>true</uniqueVersion>
+				</snapshotRepository>
+			</distributionManagement>
+			<repositories>
+				<repository>
+					<id>github-packages</id>
+					<name>Github iSantePlus Packages</name>
+					<url>https://maven.pkg.github.com/isanteplus/isanteplus-packages</url>
+				</repository>
+			</repositories>
+		</profile>
+	</profiles>
+
 	<build>
 		<pluginManagement>
 			<plugins>


### PR DESCRIPTION
Adds GitHub Actions CI (build and test) and an automated release workflow that publishes to GitHub Packages. Also adds the github-packages Maven profile to root and omod POMs, and removes the obsolete .travis.yml.